### PR TITLE
rely on nox session.venv_backend to invoke uv

### DIFF
--- a/src/nox_uv/__init__.py
+++ b/src/nox_uv/__init__.py
@@ -58,8 +58,6 @@ def session(
 
     [function] = args
 
-    is_uv = venv_backend == "uv"
-
     # Create the `uv sync` command
     sync_cmd = ["uv", "sync", "--no-default-groups"]
 
@@ -79,7 +77,7 @@ def session(
 
     @functools.wraps(function)
     def wrapper(s: nox.Session, *_args: Any, **_kwargs: Any) -> None:
-        if is_uv:
+        if s.venv_backend == "uv":
             env: dict[str, Any] = {"UV_PROJECT_ENVIRONMENT": s.virtualenv.location}
 
             # UV called from Nox does not respect the Python version set in the Nox session.


### PR DESCRIPTION
This patch uses `nox.Session.venv_backend` to determine if we are using the uv backend at the time our session is invoked. This approach takes into account the possibility of setting the `nox.options.default_venv_backend` preference to something like `uv|venv` and thus not passing the `venv_backend` option to the individual session invocations.