### PR TITLE
sync without updating lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,6 @@ jobs:
 
   all_passed:
     runs-on: ubuntu-24.04
-    needs:
-      - test
-      - quality
+    needs: [test, quality]
+    steps:
+      - run: echo "All needed jobs passed"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,3 +46,9 @@ jobs:
         run: uv sync --locked --no-default-groups
       - name: Test with Nox
         run: uv run nox -s ${{ matrix.nox-session }}
+
+  all_passed:
+    runs-on: ubuntu-24.04
+    needs:
+      - test
+      - quality

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,8 +47,4 @@ jobs:
       - name: Test with Nox
         run: uv run nox -s ${{ matrix.nox-session }}
 
-  all_passed:
-    runs-on: ubuntu-24.04
-    needs: [test, quality]
-    steps:
-      - run: echo "All needed jobs passed"
+

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-from nox import Session, parametrize, options
+from nox import Session, options, parametrize
 
 from nox_uv import session
 
@@ -65,7 +65,7 @@ def fmt(s: Session, command: list[str]) -> None:
         ["ruff", "format", "--check", "."],
     ],
 )
-def lint(s: Session, command: list[str]) -> None:
+def lint(s: Session, command: list[str]) -> list:
     s.run(*command)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-from nox import Session, options, parametrize
+from nox import Session, options, parametrize, command
 
 from nox_uv import session
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,7 +65,7 @@ def fmt(s: Session, command: list[str]) -> None:
         ["ruff", "format", "--check", "."],
     ],
 )
-def lint(s: Session, command: list[str]) -> None:
+def lint(s: Session, command: list[str]) -> list:
     s.run(*command)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,7 +65,7 @@ def fmt(s: Session, command: list[str]) -> None:
         ["ruff", "format", "--check", "."],
     ],
 )
-def lint(s: Session, command: list[str]) -> list:
+def lint(s: Session, command: list[str]) -> None:
     s.run(*command)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,4 +1,4 @@
-from nox import Session, options, parametrize, command
+from nox import Session, parametrize, options
 
 from nox_uv import session
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nox-uv"
-version = "0.2.0"
+version = "0.2.1"
 description = "Facilitate nox integration with uv for Python projects"
 readme = "README.md"
 authors = [

--- a/src/nox_uv/__init__.py
+++ b/src/nox_uv/__init__.py
@@ -58,7 +58,7 @@ def session(
     [function] = args
 
     # Create the `uv sync` command
-    sync_cmd = ["uv", "sync", "--no-default-groups"]
+    sync_cmd = ["uv", "sync", "--no-default-groups", "--locked"]
 
     # Add the groups
     for g in uv_groups:

--- a/uv.lock
+++ b/uv.lock
@@ -390,7 +390,7 @@ wheels = [
 
 [[package]]
 name = "nox-uv"
-version = "0.2.0"
+version = "0.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "nox" },


### PR DESCRIPTION
simple fix to ensure that the lock file isn't updated during the `uv sync` step.

closes #6 