### PR TITLE
export UV_PROJECT_ENVIRONMENT and UV_PYTHON with virtualenv information

### DIFF
--- a/src/nox_uv/__init__.py
+++ b/src/nox_uv/__init__.py
@@ -77,17 +77,17 @@ def session(
     @functools.wraps(function)
     def wrapper(s: nox.Session, *_args: Any, **_kwargs: Any) -> None:
         if s.venv_backend == "uv":
-            env: dict[str, Any] = {"UV_PROJECT_ENVIRONMENT": s.virtualenv.location}
+            s.env["UV_PROJECT_ENVIRONMENT"] = s.virtualenv.location
 
             # UV called from Nox does not respect the Python version set in the Nox session.
             # We need to pass the Python version to UV explicitly.
             if s.python is not None:
-                env["UV_PYTHON"] = s.python
+                # NOTE: casting to string explicitly because implicit casting isn't working
+                # for the type checker.
+                s.env["UV_PYTHON"] = str(s.python)
 
-            s.run_install(
-                *sync_cmd,
-                env=env,
-            )
+            s.run_install(*sync_cmd)
+
         function(nox.Session(s._runner), *_args, **_kwargs)
 
     return nox.session(  # type: ignore


### PR DESCRIPTION
This patch adds the session support for UV_PROJECT_ENVIRONMENT and UV_PYTHON to be forwarded to ALL run commands in the session after it has been posted. 

It limits exposure of environment variables to only projects with-in the current session so that the we don't pollute the os.environ process wide environment.
