### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is heavliy influcenced by, but much more limited than,
 This is a basic drop-in replacement for `nox.session` of [nox](https://nox.thea.codes/) to be used 
 with the [uv](https://docs.astral.sh/uv/) package manager.
 
-To use, import `session` from `nox-uv` in your `nox-file`.
+To use, import `session` from `nox-uv` in your `noxfile.py`.
 
 **NOTE**: All `@session(...)` parameters are keywords only, no positional parameters are allowed.
 
@@ -19,4 +19,3 @@ user must explicitly list the desired groups in the `uv_groups` parameter.
 - `uv_extras`: list of `uv` extras
 - `uv_all_extras`: boolean to install all extras from `pyproject.toml`
 - `uv_all_groups`: boolean to install all dependency groups
-

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 ## Intro
 
-This is heavliy influcenced by, but much more limited than, 
-[nox-poetry](https://nox-poetry.readthedocs.io).
-
 This is a basic drop-in replacement for `nox.session` of [nox](https://nox.thea.codes/) to be used 
 with the [uv](https://docs.astral.sh/uv/) package manager.
 
@@ -19,3 +16,8 @@ user must explicitly list the desired groups in the `uv_groups` parameter.
 - `uv_extras`: list of `uv` extras
 - `uv_all_extras`: boolean to install all extras from `pyproject.toml`
 - `uv_all_groups`: boolean to install all dependency groups
+
+## Inspiration
+
+This is heavliy influcenced by, but much more limited than, 
+[nox-poetry](https://nox-poetry.readthedocs.io).


### PR DESCRIPTION
- Nox's own documentation never refers to it as a "nox-file", it calls it a "Noxfile".
  - https://nox.thea.codes/en/stable/usage.html#running-all-sessions
  - I think in this case, we can be explicit and simply use the full file name.
- Additionally, move the `nox-poetry` reference to the bottom of the README. It's very possible (even likely) that new users to this package have never used `nox-poetry` and having it be the first thing someone reads could be slightly confusing.