### PR TITLE
Fix type hint for `venv_backend`

### DIFF
--- a/src/nox_uv/__init__.py
+++ b/src/nox_uv/__init__.py
@@ -16,7 +16,7 @@ def session(
     python: Python | None = None,
     reuse_venv: bool | None = None,
     name: str | None = None,
-    venv_backend: Any | None = None,
+    venv_backend: str | None = None,
     venv_params: Sequence[str] = (),
     tags: Sequence[str] | None = None,
     default: bool = True,


### PR DESCRIPTION
Closes #23 

Reference

- https://github.com/wntrblm/nox/pull/967