### PR TITLE
Set `UV_PYTHON` to session's interpreter path

### DIFF
--- a/src/nox_uv/__init__.py
+++ b/src/nox_uv/__init__.py
@@ -94,8 +94,6 @@ def session(
             # UV called from Nox does not respect the Python version set in the Nox session.
             # We need to pass the Python version to UV explicitly.
             if s.python is not None:
-                # NOTE: casting to string explicitly because implicit casting isn't working
-                # for the type checker.
                 s.env["UV_PYTHON"] = s.virtualenv.location
 
             s.run_install(*sync_cmd)

--- a/src/nox_uv/__init__.py
+++ b/src/nox_uv/__init__.py
@@ -96,7 +96,7 @@ def session(
             if s.python is not None:
                 # NOTE: casting to string explicitly because implicit casting isn't working
                 # for the type checker.
-                s.env["UV_PYTHON"] = str(s.python)
+                s.env["UV_PYTHON"] = s.virtualenv.location
 
             s.run_install(*sync_cmd)
         else:


### PR DESCRIPTION
We should follow the Nox cookbook and not only set the Python _version_ explicitly, but, even better, set the entire Python interpreter path so that we guarantee that `uv sync` targets the session's venv properly

- https://nox.thea.codes/en/stable/cookbook.html#using-a-lockfile

Currently, without this PR, we are only only setting `"3.12"` for `--python`. With `UV_PROJECT_ENVIRONMENT` set, this is _probably_ okay (seems to work) but it seems much safer to explicitly list the _exact_ interpreter that we want.