### PR TITLE
Make `type_check` dependency group name match session name

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -67,6 +67,6 @@ def lint_fix(s: Session) -> None:
     s.run("ruff", "check", ".", "--extend-fixable", "F401", "--fix")
 
 
-@session(uv_groups=["test", "type-check"])
+@session(uv_groups=["test", "type_check"])
 def type_check(s: Session) -> None:
     s.run("mypy", "src", "tests", "noxfile.py")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ test = [
     "pytest<8.4.0",
     "pytest-cov>=6.0.0",
 ]
-type-check = [
+type_check = [
     "mypy>=1.15.0",
 ]
 

--- a/tests/subproject/noxfile.py
+++ b/tests/subproject/noxfile.py
@@ -87,11 +87,11 @@ def only_groups(s: Session) -> None:
     assert "nox-uv" not in r
 
 
-@session(uv_groups=["type-check"], venv_backend="virtualenv")
+@session(uv_groups=["type_check"], venv_backend="virtualenv")
 def failed_virtualenv(s: Session) -> None:
     pass
 
 
-@session(uv_groups=["type-check"], venv_backend="none")
+@session(uv_groups=["type_check"], venv_backend="none")
 def failed_venv_none(s: Session) -> None:
     pass

--- a/tests/subproject/pyproject.toml
+++ b/tests/subproject/pyproject.toml
@@ -29,7 +29,7 @@ lint = [
 test = [
     "pytest-cov>=6.0.0",
 ]
-type-check = [
+type_check = [
     "mypy>=1.15.0",
 ]
 
@@ -37,5 +37,5 @@ type-check = [
 default-groups = [
     "lint",
     "test",
-    "type-check",
+    "type_check",
 ]


### PR DESCRIPTION
Since Nox sessions must be Python identifies (e.g., must be `type_check` rather than `type-check`), use `type_check` for the dependency group name too so that they match.