### PR TITLE
Allow for --no-venv

### DIFF
--- a/src/nox_uv/__init__.py
+++ b/src/nox_uv/__init__.py
@@ -133,6 +133,11 @@ def session(
                 f"UV_PROJECT_ENVIRONMENT={s.env['UV_PROJECT_ENVIRONMENT']}"
             )
             s.run_install(*sync_cmd)
+        elif s.venv_backend == 'none':
+            # Allow users to re-use an existing venv with `nox --no-venv`
+            # (aka `--force-venv-backend none`).
+            s.warn('No venv_backend specified, reusing existing venv. '
+                   '"uv" specific parameters will be ignored.')
         else:
             if len(extended_cmd) > 0:
                 raise s.error(

--- a/tests/test_lib.py
+++ b/tests/test_lib.py
@@ -16,17 +16,34 @@ def test_run_uv_nox() -> None:
     assert a.returncode == 0
 
 
-def test_run_failed_uv_venv() -> None:
+def test_venv_backend_uv_no_errors() -> None:
+    """Using the 'uv' backend with uv-specific parameters succeeds without errors."""
     a = subprocess.run(
-        ["uv", "run", "python", "-m", "nox", "-s", "failed_virtualenv"],
+        ["uv", "run", "python", "-m", "nox", "-s", "test_group"],
         capture_output=True,
         cwd=TESTING_FOLDER,
     )
-    assert a.returncode == 1  # This test is expected to fail with a `Session.error` raised.
-    assert "is not allowed" in a.stderr.decode()
+    assert a.returncode == 0
+    assert "error" not in a.stderr.decode().lower()
 
+
+def test_venv_backend_none_warning() -> None:
+    """Using 'none' backend with uv-specific parameters emits a warning but succeeds."""
     a = subprocess.run(
         ["uv", "run", "python", "-m", "nox", "-s", "failed_venv_none"],
+        capture_output=True,
+        cwd=TESTING_FOLDER,
+    )
+    assert a.returncode == 0
+    stderr = a.stderr.decode()
+    assert "No venv_backend specified, reusing existing venv." in stderr
+    assert '"uv" specific parameters will be ignored.' in stderr
+
+
+def test_venv_backend_other_error() -> None:
+    """Using a backend other than 'uv' or 'none' with uv-specific parameters raises an error."""
+    a = subprocess.run(
+        ["uv", "run", "python", "-m", "nox", "-s", "failed_virtualenv"],
         capture_output=True,
         cwd=TESTING_FOLDER,
     )


### PR DESCRIPTION
Allow users to re-use an existing venv with `nox --no-venv` (aka
`--force-venv-backend none`). Instad of a (fatal) error, users will only
get a warning.

This is useful for cases where a nox session has a complex command to
run, but the (development) venv has already everything needed to run the
command.

In our case, it's a command to build and preview Sphinx-based
documentation, for which we don't want to create another venv.
